### PR TITLE
Simplify Reader Interface

### DIFF
--- a/caps.go
+++ b/caps.go
@@ -8,10 +8,8 @@ import (
 const DefaultLang = "en-US"
 
 type CaptionReader interface {
-	Read([]byte) (*CaptionSet, error)
-	ReadString(string) (*CaptionSet, error)
-	Detect([]byte) bool
-	DetectString(string) bool
+	Read(string) (*CaptionSet, error)
+	Detect(string) bool
 }
 
 type CaptionWriter interface {

--- a/dfxp/dfxp_test.go
+++ b/dfxp/dfxp_test.go
@@ -91,23 +91,23 @@ const sampleDFXPEmpty = `
 `
 
 func TestDection(t *testing.T) {
-	assert.True(t, NewReader().DetectString(sampleDFXP))
+	assert.True(t, NewReader().Detect(sampleDFXP))
 }
 
 func TestCaptionLength(t *testing.T) {
-	captionSet, err := NewReader().ReadString(sampleDFXP)
+	captionSet, err := NewReader().Read(sampleDFXP)
 	assert.Nil(t, err)
 	assert.Equal(t, 7, len(captionSet.GetCaptions("en-US")))
 }
 
 func TestEmptyFile(t *testing.T) {
-	set, err := NewReader().ReadString(sampleDFXPEmpty)
+	set, err := NewReader().Read(sampleDFXPEmpty)
 	assert.NotNil(t, err)
 	assert.True(t, set.IsEmpty())
 }
 
 func TestProperTimestamps(t *testing.T) {
-	captionSet, err := NewReader().ReadString(sampleDFXP)
+	captionSet, err := NewReader().Read(sampleDFXP)
 	assert.Nil(t, err)
 
 	paragraph := captionSet.GetCaptions("en-US")[2]
@@ -116,13 +116,13 @@ func TestProperTimestamps(t *testing.T) {
 }
 
 func TestInvalidMarkupIsProperlyHandled(t *testing.T) {
-	captionSet, err := NewReader().ReadString(sampleDFXPSyntaxError)
+	captionSet, err := NewReader().Read(sampleDFXPSyntaxError)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(captionSet.GetCaptions("en-US")))
 }
 
 func TestCaptionNodes(t *testing.T) {
-	captionSet, err := NewReader().ReadString(sampleDFXP)
+	captionSet, err := NewReader().Read(sampleDFXP)
 	assert.Nil(t, err)
 	styles := captionSet.GetStyles()
 	assert.Equal(t, 1, len(styles))
@@ -209,7 +209,7 @@ func TestStructToXML(t *testing.T) {
 }
 
 //func TestDFXPWriter(t *testing.T) {
-//	captionSet, err := NewReader().ReadString(sampleDFXP)
+//	captionSet, err := NewReader().Read(sampleDFXP)
 //	assert.Nil(t, err)
 //	data, _ := NewWriter().Write(captionSet)
 //	fmt.Println(sampleDFXP[0])

--- a/dfxp/reader.go
+++ b/dfxp/reader.go
@@ -18,19 +18,11 @@ type Reader struct {
 	nodes      []caps.CaptionContent
 }
 
-func (Reader) DetectString(content string) bool {
+func (Reader) Detect(content string) bool {
 	return strings.Contains(strings.ToLower(content), "</tt>")
 }
 
-func (r Reader) Detect(content []byte) bool {
-	return r.DetectString(string(content))
-}
-
-func (r Reader) Read(content []byte) (*caps.CaptionSet, error) {
-	return r.ReadString(string(content))
-}
-
-func (r Reader) ReadString(content string) (*caps.CaptionSet, error) {
+func (r Reader) Read(content string) (*caps.CaptionSet, error) {
 	doc, err := xmlquery.Parse(strings.NewReader(content))
 	if err != nil {
 		return nil, err

--- a/scc/reader.go
+++ b/scc/reader.go
@@ -32,27 +32,15 @@ const defaultLang = "en-US"
 
 var timestampWords = regexp.MustCompile(`([0-9:;]*)([\s\t]*)((.)*)`)
 
-func (Reader) Detect(content []byte) bool {
-	return strings.HasPrefix(strings.TrimLeft(string(content), " "), header)
-}
-
-func (Reader) DetectString(content string) bool {
+func (Reader) Detect(content string) bool {
 	return strings.HasPrefix(strings.TrimLeft(content, " "), header)
 }
 
-func (r *Reader) ReadLang(content []byte, lang string) (*caps.CaptionSet, error) {
-	return r.ReadStringLang(string(content), lang)
+func (r *Reader) Read(content string) (*caps.CaptionSet, error) {
+	return r.ReadLang(content, defaultLang)
 }
 
-func (r *Reader) Read(content []byte) (*caps.CaptionSet, error) {
-	return r.ReadStringLang(string(content), defaultLang)
-}
-
-func (r *Reader) ReadString(content string) (*caps.CaptionSet, error) {
-	return r.ReadStringLang(content, defaultLang)
-}
-
-func (r *Reader) ReadStringLang(content string, lang string) (*caps.CaptionSet, error) {
+func (r *Reader) ReadLang(content string, lang string) (*caps.CaptionSet, error) {
 	lines := strings.Split(content, "\n")
 	for _, line := range lines[1:] {
 		r.translateLine(line)

--- a/scc/scc_test.go
+++ b/scc/scc_test.go
@@ -57,13 +57,13 @@ const sampleSCCempty = `Scenarist_SCC V1.0
 `
 
 func TestDetect(t *testing.T) {
-	if !DefaultReader().DetectString(sampleSCC) {
+	if !DefaultReader().Detect(sampleSCC) {
 		t.Error("valid scc sample should be detected")
 	}
 }
 
 func TestCaptionLength(t *testing.T) {
-	captionSet, err := DefaultReader().ReadString(sampleSCC)
+	captionSet, err := DefaultReader().Read(sampleSCC)
 	if err != nil {
 		t.Errorf("scc reader failed: %v", err)
 	}
@@ -74,7 +74,7 @@ func TestCaptionLength(t *testing.T) {
 }
 
 func TestCaptionContent(t *testing.T) {
-	captionSet, err := DefaultReader().ReadString(sampleSCC)
+	captionSet, err := DefaultReader().Read(sampleSCC)
 	if err != nil {
 		t.Errorf("scc reader failed: %v", err)
 	}
@@ -89,7 +89,7 @@ func TestCaptionContent(t *testing.T) {
 }
 
 func TestEmptyFile(t *testing.T) {
-	_, err := DefaultReader().ReadString(sampleSCCempty)
+	_, err := DefaultReader().Read(sampleSCCempty)
 	if err == nil {
 		t.Errorf("should have returned an error")
 	}
@@ -104,7 +104,7 @@ func TestWriter(t *testing.T) {
 		{inputSCC: sampleSCC, wantSCC: sccSamplePostCapsConvertion},
 	}
 	for _, test := range srtConvertionTests {
-		captionsSet, err := DefaultReader().ReadString(test.inputSCC)
+		captionsSet, err := DefaultReader().Read(test.inputSCC)
 		assert.Nil(t, err)
 		result, _ := NewWriter().Write(captionsSet)
 		assert.Equal(t, test.wantSCC, string(result))

--- a/srt/reader.go
+++ b/srt/reader.go
@@ -10,30 +10,18 @@ import (
 
 type Reader struct{}
 
-func (r Reader) Detect(content []byte) bool {
-	return r.DetectString(string(content))
-}
-
-func (Reader) DetectString(content string) bool {
+func (Reader) Detect(content string) bool {
 	lines := splitLines(content)
 	if len(lines) < 2 {
 		return false
 	}
 	return isDigit(lines[0]) && strings.Contains(lines[1], "-->")
 }
-func (r Reader) ReadString(content string) (*caps.CaptionSet, error) {
-	return r.ReadStringWithLang(content, caps.DefaultLang)
-}
-
-func (r Reader) Read(content []byte) (*caps.CaptionSet, error) {
+func (r Reader) Read(content string) (*caps.CaptionSet, error) {
 	return r.ReadWithLang(content, caps.DefaultLang)
 }
 
-func (r Reader) ReadWithLang(content []byte, lang string) (*caps.CaptionSet, error) {
-	return r.ReadStringWithLang(string(content), lang)
-}
-
-func (Reader) ReadStringWithLang(content string, lang string) (*caps.CaptionSet, error) {
+func (Reader) ReadWithLang(content string, lang string) (*caps.CaptionSet, error) {
 	captionSet := caps.NewCaptionSet()
 	captions := []*caps.Caption{}
 	lines := splitLines(content)

--- a/srt/srt_test.go
+++ b/srt/srt_test.go
@@ -7,19 +7,19 @@ import (
 )
 
 func TestSRTDetection(t *testing.T) {
-	assert.True(t, Reader{}.DetectString(sampleSRT))
+	assert.True(t, Reader{}.Detect(sampleSRT))
 }
 
 func TestSRTCaptionLength(t *testing.T) {
 	reader := NewReader()
-	captions, err := reader.ReadString(sampleSRT)
+	captions, err := reader.Read(sampleSRT)
 	assert.Nil(t, err)
 	assert.Equal(t, 8, len(captions.GetCaptions("en-US")))
 }
 
 func TestSRTTimestamp(t *testing.T) {
 	reader := NewReader()
-	captions, err := reader.ReadString(sampleSRT)
+	captions, err := reader.Read(sampleSRT)
 	assert.Nil(t, err)
 	p := captions.GetCaptions("en-US")[2]
 	assert.Equal(t, 17000000, int(p.Start))
@@ -28,20 +28,20 @@ func TestSRTTimestamp(t *testing.T) {
 
 func TestSRTNumeric(t *testing.T) {
 	reader := NewReader()
-	captions, err := reader.ReadString(sampleSRTnumeric)
+	captions, err := reader.Read(sampleSRTnumeric)
 	assert.Nil(t, err)
 	assert.Equal(t, 7, len(captions.GetCaptions("en-US")))
 }
 
 func TestSRTEmptyFile(t *testing.T) {
 	reader := NewReader()
-	_, err := reader.ReadString(sampleSRTempty)
+	_, err := reader.Read(sampleSRTempty)
 	assert.NotNil(t, err)
 }
 
 func TestSRTExtraEmpty(t *testing.T) {
 	reader := NewReader()
-	captions, err := reader.ReadString(sampleSRTblankLines)
+	captions, err := reader.Read(sampleSRTblankLines)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(captions.GetCaptions("en-US")))
 }
@@ -57,7 +57,7 @@ func TestSRTtoSRT(t *testing.T) {
 		{inputSRT: sampleSRTu, wantSRT: sampleSRTu},
 	}
 	for _, test := range srtConvertionTests {
-		captions, err := NewReader().ReadString(test.inputSRT)
+		captions, err := NewReader().Read(test.inputSRT)
 		assert.Nil(t, err)
 		result, _ := NewWriter().Write(captions)
 		assert.Equal(t, string(result), test.wantSRT)


### PR DESCRIPTION
Simplify the reader interface, remove Read([]byte) and Detect([]byte) functions, as the user can just cast the byte input to string