### PR TITLE
Minor fixes and cleanup for SRT package

### DIFF
--- a/srt/reader.go
+++ b/srt/reader.go
@@ -15,7 +15,7 @@ func (Reader) Detect(content []byte) bool {
 	if len(lines) < 2 {
 		return false
 	}
-	return isDigit(lines[0]) && strings.Contains(lines[1], "-->")
+	return isDigit(lines[0]) && strings.Contains(lines[1], timecodeSeparator)
 }
 func (r Reader) Read(content []byte) (*caps.CaptionSet, error) {
 	captionSet := caps.NewCaptionSet()
@@ -41,7 +41,7 @@ func (r Reader) Read(content []byte) (*caps.CaptionSet, error) {
 				return nil, err
 			}
 		} else {
-			timing := strings.Split(lines[startLine+1], "-->")
+			timing := strings.Split(lines[startLine+1], timecodeSeparator)
 			if len(timing) < 2 {
 				return nil, fmt.Errorf("malformed srt file")
 			}
@@ -59,7 +59,7 @@ func (r Reader) Read(content []byte) (*caps.CaptionSet, error) {
 			cleanLine := reFont.ReplaceAllString(line, "")
 			cleanLine = reEndFont.ReplaceAllString(cleanLine, "")
 			if len(capNodes) == 0 || line != "" {
-				capNodes = append(capNodes, caps.NewCaptionText(line))
+				capNodes = append(capNodes, caps.NewCaptionText(cleanLine))
 				capNodes = append(capNodes, caps.NewLineBreak())
 			}
 		}

--- a/srt/srt.go
+++ b/srt/srt.go
@@ -6,9 +6,11 @@ import (
 	"github.com/thiagopnts/caps"
 )
 
+const timecodeSeparator = "-->"
+
 var re = regexp.MustCompile("[0-9]{1,}")
 var reTiming = regexp.MustCompile("^([0-9]{1,}:[0-9]{1,}:[0-9]{1,},[0-9]{1,}) --> ([0-9]{1,}:[0-9]{1,}:[0-9]{1,},[0-9]{1,})")
-var reFont = regexp.MustCompile("(?i)<font color=\"#[0-9a-f]{6}\">")
+var reFont = regexp.MustCompile("(?i)<font color=\"[0-9a-zA-Z]*\">")
 var reEndFont = regexp.MustCompile("(?i)</font>")
 
 func NewReader() caps.CaptionReader {

--- a/srt/srt_test.go
+++ b/srt/srt_test.go
@@ -1,7 +1,6 @@
 package srt
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,12 +29,13 @@ func TestSRTTimestamp(t *testing.T) {
 	assert.Equal(t, 18752000, int(p.End))
 }
 
-func TestSRTFontColor(t *testing.T) {
+func TestSRTStripFontColor(t *testing.T) {
 	reader := NewReader()
 	captions, err := reader.Read(SampleSRTFontColor)
+	text := captions.GetCaptions(caps.DefaultLang)[3].Nodes[0].Content()
 	assert.Nil(t, err)
 	assert.Equal(t, 4, len(captions.GetCaptions(caps.DefaultLang)))
-	fmt.Println(captions.GetCaptions(caps.DefaultLang)[3])
+	assert.Equal(t, "as an old, wrinkly man", text)
 }
 
 func TestSRTNumeric(t *testing.T) {
@@ -210,7 +210,7 @@ of "E equals m c-squared",
 
 4
 00:00:18,752 --> 00:00:20,887
-<font color=“white”>as an old, wrinkly man</font>
+<font color="white">as an old, wrinkly man</font>
 `)
 
 var SampleSRTNumeric = []byte(`35

--- a/srt/srt_test.go
+++ b/srt/srt_test.go
@@ -1,49 +1,61 @@
 package srt
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/thiagopnts/caps"
 )
 
 func TestSRTDetection(t *testing.T) {
-	assert.True(t, Reader{}.Detect(sampleSRT))
+	assert.True(t, Reader{}.Detect(SampleSRT))
+	assert.False(t, Reader{}.Detect(InvalidSRT1))
+	assert.False(t, Reader{}.Detect(InvalidSRT2))
 }
 
 func TestSRTCaptionLength(t *testing.T) {
 	reader := NewReader()
-	captions, err := reader.Read(sampleSRT)
+	captions, err := reader.Read(SampleSRT)
 	assert.Nil(t, err)
-	assert.Equal(t, 8, len(captions.GetCaptions("en-US")))
+	assert.Equal(t, 8, len(captions.GetCaptions(caps.DefaultLang)))
 }
 
 func TestSRTTimestamp(t *testing.T) {
 	reader := NewReader()
-	captions, err := reader.Read(sampleSRT)
+	captions, err := reader.Read(SampleSRT)
 	assert.Nil(t, err)
-	p := captions.GetCaptions("en-US")[2]
+	p := captions.GetCaptions(caps.DefaultLang)[2]
 	assert.Equal(t, 17000000, int(p.Start))
 	assert.Equal(t, 18752000, int(p.End))
 }
 
+func TestSRTFontColor(t *testing.T) {
+	reader := NewReader()
+	captions, err := reader.Read(SampleSRTFontColor)
+	assert.Nil(t, err)
+	assert.Equal(t, 4, len(captions.GetCaptions(caps.DefaultLang)))
+	fmt.Println(captions.GetCaptions(caps.DefaultLang)[3])
+}
+
 func TestSRTNumeric(t *testing.T) {
 	reader := NewReader()
-	captions, err := reader.Read(sampleSRTnumeric)
+	captions, err := reader.Read(SampleSRTNumeric)
 	assert.Nil(t, err)
-	assert.Equal(t, 7, len(captions.GetCaptions("en-US")))
+	assert.Equal(t, 7, len(captions.GetCaptions(caps.DefaultLang)))
 }
 
 func TestSRTEmptyFile(t *testing.T) {
 	reader := NewReader()
-	_, err := reader.Read(sampleSRTempty)
+	_, err := reader.Read(SampleSRTEmpty)
 	assert.NotNil(t, err)
 }
 
 func TestSRTExtraEmpty(t *testing.T) {
 	reader := NewReader()
-	captions, err := reader.Read(sampleSRTblankLines)
+	captions, err := reader.Read(SampleSRTBlankLines)
 	assert.Nil(t, err)
-	assert.Equal(t, 2, len(captions.GetCaptions("en-US")))
+	assert.Equal(t, 2, len(captions.GetCaptions(caps.DefaultLang)))
 }
 
 func TestSRTtoSRT(t *testing.T) {
@@ -52,9 +64,9 @@ func TestSRTtoSRT(t *testing.T) {
 		wantSRT  []byte
 	}
 	srtConvertionTests := []srtToSRTTests{
-		{inputSRT: sampleSRT, wantSRT: sampleSRT},
-		{inputSRT: sampleSRTutf8, wantSRT: sampleSRTutf8},
-		{inputSRT: sampleSRTu, wantSRT: sampleSRTu},
+		{inputSRT: SampleSRT, wantSRT: SampleSRT},
+		{inputSRT: SampleSRTutf8, wantSRT: SampleSRTutf8},
+		{inputSRT: SampleSRTUnicode, wantSRT: SampleSRTUnicode},
 	}
 	for _, test := range srtConvertionTests {
 		captions, err := NewReader().Read(test.inputSRT)
@@ -64,7 +76,16 @@ func TestSRTtoSRT(t *testing.T) {
 	}
 }
 
-var sampleSRTu = []byte(`1
+var InvalidSRT1 = []byte(`1
+blank line
+`)
+
+var InvalidSRT2 = []byte(`1
+00:00:09,209 -> 00:00:12,312
+incorrect separator
+`)
+
+var SampleSRTUnicode = []byte(`1
 00:00:09,209 --> 00:00:12,312
 ( clock ticking )
 
@@ -99,7 +120,7 @@ It's all about an eternal Einstein.
 <LAUGHING & WHOOPS!>
 `)
 
-var sampleSRTutf8 = []byte(`1
+var SampleSRTutf8 = []byte(`1
 00:00:09,209 --> 00:00:12,312
 ( clock ticking )
 
@@ -134,7 +155,7 @@ It's all about an eternal Einstein.
 <LAUGHING & WHOOPS!>
 `)
 
-var sampleSRT = []byte(`1
+var SampleSRT = []byte(`1
 00:00:09,209 --> 00:00:12,312
 ( clock ticking )
 
@@ -173,7 +194,26 @@ It's all about an eternal Einstein.
 some more text
 `)
 
-var sampleSRTnumeric = []byte(`35
+var SampleSRTFontColor = []byte(`1
+00:00:09,209 --> 00:00:12,312
+( clock ticking )
+
+2
+00:00:14,848 --> 00:00:17,000
+MAN:
+When we think
+of "E equals m c-squared",
+
+3
+00:00:17,000 --> 00:00:18,752
+<LAUGHING & WHOOPS!>
+
+4
+00:00:18,752 --> 00:00:20,887
+<font color=“white”>as an old, wrinkly man</font>
+`)
+
+var SampleSRTNumeric = []byte(`35
 00:00:32,290 --> 00:00:32,890
 TO  FIND  HIM.            IF
 
@@ -202,10 +242,10 @@ STD  OUT
 3
 `)
 
-var sampleSRTempty = []byte(`
+var SampleSRTEmpty = []byte(`
 `)
 
-var sampleSRTblankLines []byte = []byte(`35
+var SampleSRTBlankLines []byte = []byte(`35
 00:00:32,290 --> 00:00:32,890
 
 

--- a/srt/writer.go
+++ b/srt/writer.go
@@ -28,14 +28,16 @@ func recreateLang(captions []*caps.Caption) string {
 	count := 1
 	for _, caption := range captions {
 		content += fmt.Sprintf("%s\n", strconv.Itoa(count))
+
 		start := caption.FormatStartWithSeparator(",")
 		end := caption.FormatEndWithSeparator(",")
-		content += fmt.Sprintf("%s --> %s\n", start[:12], end[:12])
-		newContent := ""
+		content += fmt.Sprintf("%s %s %s\n", start[:12], timecodeSeparator, end[:12])
+
+		lines := ""
 		for _, node := range caption.Nodes {
-			newContent += recreateLine(node)
+			lines += recreateLine(node)
 		}
-		content += fmt.Sprintf("%s\n\n", strings.ReplaceAll(newContent, "\n\n", "\n"))
+		content += fmt.Sprintf("%s\n\n", strings.ReplaceAll(lines, "\n\n", "\n"))
 		count++
 	}
 	return content[:len(content)-1]


### PR DESCRIPTION
Few small improvements to the SRT package:

- Fixes an issue where font color wasn't being stripped from caption text correctly
- Updated the font color regex pattern to be more generic after checking the SRT spec online (i.e. `<font color=“anystring”></font>` is matched instead of just `<font color=“#001f3f”></font>`)
- Adds a test ensuring font color is stripped correctly
- Uses the `caps.DefaultLang` const instead of `en-US`
- Adds a few tests ensuring invalid SRT files fail detection
- Uppercases naming of the SRT fixture files so they'll be exported and available for when we add SRT -> (Other caption format) conversion tests