### PR TITLE
Add tests for srt helper methods

### DIFF
--- a/srt/reader.go
+++ b/srt/reader.go
@@ -100,27 +100,24 @@ func srtToMicro(stamp string) (int64, error) {
 	if !strings.Contains(timesplit[2], ",") {
 		timesplit[2] = fmt.Sprintf("%s,000", timesplit[2])
 	}
+	timesplit0, err := strconv.ParseInt(timesplit[0], base10, bitSize64)
+	if err != nil {
+		return 0, err
+	}
+	timesplit1, err := strconv.ParseInt(timesplit[1], base10, bitSize64)
+	if err != nil {
+		return 0, err
+	}
 	secsplit := strings.Split(timesplit[2], ",")
-	timesplit0, err := strconv.ParseInt(timesplit[0], 10, 64)
+	secsplit0, err := strconv.ParseInt(secsplit[0], base10, bitSize64)
 	if err != nil {
 		return 0, err
 	}
-	timesplit1, err := strconv.ParseInt(timesplit[1], 10, 64)
+	secsplit1, err := strconv.ParseInt(secsplit[1], base10, bitSize64)
 	if err != nil {
 		return 0, err
 	}
-	secsplit0, err := strconv.ParseInt(secsplit[0], 10, 64)
-	if err != nil {
-		return 0, err
-	}
-	secsplit1, err := strconv.ParseInt(secsplit[1], 10, 64)
-	if err != nil {
-		return 0, err
-	}
-	microseconds := timesplit0*3600000000 +
-		timesplit1*60000000 +
-		secsplit0*1000000 +
-		secsplit1*1000
+	microseconds := timesplit0*microHr + timesplit1*microMin + secsplit0*microSec + secsplit1*microMilli
 	return microseconds, nil
 }
 

--- a/srt/reader_test.go
+++ b/srt/reader_test.go
@@ -1,0 +1,92 @@
+package srt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindTextLine(t *testing.T) {
+	var sampleLines = []string{"00:00:10,200 --> 00:00:12,300", "test line", "another test line", "", "00:00:11,300 --> 00:00:15,200", "test line 2", ""}
+
+	tests := []struct {
+		name           string
+		inputStartLine int
+		expected       int
+	}{
+		{"find text line - return endLine of first cue", 0, 4},
+		{"find text line - return endLine of second cue", 4, 8},
+		{"find text line - endLine > # of lines", 8, 9},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := findTextLine(test.inputStartLine, sampleLines)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestSRTtoMicro(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected int64
+		err      string
+	}{
+		{"parse timestamp - happy path", "23:59:59,999", 86399999000, ""},
+		{"parse timestamp - milliseconds missing", "23:00:00", 82800000000, ""},
+		{"parse invalid timestamp - hours missing", "59:00,000", 0, "invalid srt timestamp"},
+		{"parse invalid milliseconds", "00:00:00,9z9", 0, "strconv.ParseInt: parsing \"9z9\": invalid syntax"},
+		{"parse invalid seconds", "00:00:5z,000", 0, "strconv.ParseInt: parsing \"5z\": invalid syntax"},
+		{"parse invalid minutes", "00:5z:00,000", 0, "strconv.ParseInt: parsing \"5z\": invalid syntax"},
+		{"parse invalid hours", "2z:00:00,000", 0, "strconv.ParseInt: parsing \"2z\": invalid syntax"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actualMicro, err := srtToMicro(test.input)
+			if test.err == "" {
+				assert.NoError(t, err)
+				assert.Equal(t, test.expected, actualMicro)
+			} else {
+				assert.EqualError(t, err, test.err)
+			}
+		})
+	}
+}
+
+func TestIsDigit(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{"is digit - single digit", "0", true},
+		{"is digit - multiple digits", "123456789", true},
+		{"is digit - digit and letters", "1xx", false},
+		{"is digit - letters", "test", false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := isDigit(test.input)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestSplitLines(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{"split line - no breaks", `00:00:10,200 --> 00:00:12,300`, []string{`00:00:10,200 --> 00:00:12,300`}},
+		{"split line - one line break", "00:00:10,200 --> 00:00:12,300\r\ntest line", []string{"00:00:10,200 --> 00:00:12,300", "test line"}},
+		{"split line - multiple breaks", "00:00:10,200 --> 00:00:12,300\n\r\ntest line", []string{"00:00:10,200 --> 00:00:12,300", "", "test line"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := splitLines(test.input)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}

--- a/srt/srt.go
+++ b/srt/srt.go
@@ -6,12 +6,22 @@ import (
 	"github.com/vimeo/caps"
 )
 
-const timecodeSeparator = "-->"
+const (
+	base10            int    = 10
+	bitSize64         int    = 64
+	microHr           int64  = 3600000000
+	microMin          int64  = 60000000
+	microSec          int64  = 1000000
+	microMilli        int64  = 1000
+	timecodeSeparator string = "-->"
+)
 
-var re = regexp.MustCompile("[0-9]{1,}")
-var reTiming = regexp.MustCompile("^([0-9]{1,}:[0-9]{1,}:[0-9]{1,},[0-9]{1,}) --> ([0-9]{1,}:[0-9]{1,}:[0-9]{1,},[0-9]{1,})")
-var reFont = regexp.MustCompile("(?i)<font color=\"[0-9a-zA-Z]*\">")
-var reEndFont = regexp.MustCompile("(?i)</font>")
+var (
+	re        = regexp.MustCompile("^[0-9]{1,}$")
+	reTiming  = regexp.MustCompile("^([0-9]{1,}:[0-9]{1,}:[0-9]{1,},[0-9]{1,}) --> ([0-9]{1,}:[0-9]{1,}:[0-9]{1,},[0-9]{1,})")
+	reFont    = regexp.MustCompile("(?i)<font color=\"[0-9a-zA-Z]*\">")
+	reEndFont = regexp.MustCompile("(?i)</font>")
+)
 
 func NewReader() caps.CaptionReader {
 	return Reader{}

--- a/srt/srt_test.go
+++ b/srt/srt_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/thiagopnts/caps"
+	"github.com/vimeo/caps"
 )
 
 func TestSRTDetection(t *testing.T) {


### PR DESCRIPTION
- Adds tests for SRT reader helper methods
- Replace magic numbers in SRT reader with constants
- Fix the `re` regex pattern, so that it only matches on digits (previously,  letters and digits were matched without error)