### PR TITLE
Add tests for webvtt reader

### DIFF
--- a/webvtt/reader.go
+++ b/webvtt/reader.go
@@ -9,31 +9,21 @@ import (
 	"github.com/vimeo/caps"
 )
 
-var timingPattern = regexp.MustCompile("^(.+?) --> (.+)")
-var timestampPattern = regexp.MustCompile(`^(\d+):(\d{2})(:\d{2})?\.(\d{3})`)
-var voiceSpanPattern = regexp.MustCompile(`<v(\\.\\w+)* ([^>]*)>`)
-var otherSpanPattern = regexp.MustCompile("</?([cibuv]|ruby|rt|lang).*?>")
-var webvttTiming = "-->"
+const (
+	bitSize64  int     = 64
+	secHr      float64 = 3600
+	secMin     float64 = 60
+	microSec   float64 = 1000000
+	microMilli float64 = 1000
+)
 
-func microseconds(h, m, s, f string) (float64, error) {
-	hh, err := strconv.ParseFloat(h, 64)
-	if err != nil {
-		return 0, err
-	}
-	mm, err := strconv.ParseFloat(m, 64)
-	if err != nil {
-		return 0, err
-	}
-	ss, err := strconv.ParseFloat(s, 64)
-	if err != nil {
-		return 0, err
-	}
-	ff, err := strconv.ParseFloat(f, 64)
-	if err != nil {
-		return 0, err
-	}
-	return (hh*3600+mm*60+ss)*1000000 + ff*1000, nil
-}
+var (
+	timingPattern    = regexp.MustCompile("^(.+?) --> (.+)")
+	timestampPattern = regexp.MustCompile(`^(\d+):(\d{2}):?(\d{2})?\.(\d{3})`)
+	voiceSpanPattern = regexp.MustCompile(`<v(\\.\\w+)* ([^>]*)>`)
+	otherSpanPattern = regexp.MustCompile("</?([cibuv]|ruby|rt|lang).*?>")
+	webvttTiming     = "-->"
+)
 
 type reader struct {
 	ignoreTimingErrors bool
@@ -66,7 +56,7 @@ func (r *reader) parse(lines []string) ([]*caps.Caption, error) {
 			if len(captions) != 0 {
 				lastStartTime = *captions[len(captions)-1].Start
 			}
-			caption, err = r.parseTimingLine(line, lastStartTime)
+			caption, err = parseTimingLine(line, lastStartTime, r.ignoreTimingErrors)
 			if err != nil {
 				return nil, fmt.Errorf("error parsing timing line %d: %w", timingLine, err)
 			}
@@ -83,7 +73,7 @@ func (r *reader) parse(lines []string) ([]*caps.Caption, error) {
 				if caption != nil && !caption.IsEmpty() {
 					caption.Nodes = append(caption.Nodes, caps.NewLineBreak())
 				}
-				caption.Nodes = append(caption.Nodes, caps.NewCaptionText(r.removeStyles(line)))
+				caption.Nodes = append(caption.Nodes, caps.NewCaptionText(removeStyles(line)))
 			}
 		}
 	}
@@ -93,7 +83,73 @@ func (r *reader) parse(lines []string) ([]*caps.Caption, error) {
 	return captions, nil
 }
 
-func (r *reader) validateTimings(caption *caps.Caption, lastStartTime float64) error {
+func (r *reader) Detect(content []byte) bool {
+	return strings.Contains(string(content), "WEBVTT")
+}
+
+// Reader helpers
+func microseconds(h, m, s, f string) (float64, error) {
+	hh, err := strconv.ParseFloat(h, bitSize64)
+	if err != nil {
+		return 0, err
+	}
+	mm, err := strconv.ParseFloat(m, bitSize64)
+	if err != nil {
+		return 0, err
+	}
+	ss, err := strconv.ParseFloat(s, bitSize64)
+	if err != nil {
+		return 0, err
+	}
+	ff, err := strconv.ParseFloat(f, bitSize64)
+	if err != nil {
+		return 0, err
+	}
+	return (hh*secHr+mm*secMin+ss)*microSec + ff*microMilli, nil
+}
+
+func parseTimingLine(line string, lastStartTime float64, ignoreTimingErrors bool) (*caps.Caption, error) {
+	matches := timingPattern.FindStringSubmatch(line)
+	if len(matches) < 3 {
+		return nil, fmt.Errorf("invalid timing format")
+	}
+	start, err := parseTimestamp(matches[1])
+	if err != nil {
+		return nil, err
+	}
+	end, err := parseTimestamp(matches[2])
+	if err != nil {
+		return nil, err
+	}
+	caption := &caps.Caption{Start: start, End: end}
+	if !ignoreTimingErrors {
+		err := validateTimings(caption, lastStartTime)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return caption, nil
+}
+
+func parseTimestamp(input string) (*float64, error) {
+	matches := timestampPattern.FindStringSubmatch(input)
+	if len(matches) < 5 {
+		return nil, nil
+	}
+	if matches[3] != "" {
+		tmstp, err := microseconds(matches[1], matches[2], strings.ReplaceAll(matches[3], ":", ""), matches[4])
+		return &tmstp, err
+	}
+	tmstp, err := microseconds("0", matches[1], matches[2], matches[4])
+	return &tmstp, err
+}
+
+func removeStyles(line string) string {
+	partialResult := voiceSpanPattern.ReplaceAllString(line, "\\2: ")
+	return otherSpanPattern.ReplaceAllString(partialResult, "")
+}
+
+func validateTimings(caption *caps.Caption, lastStartTime float64) error {
 	// FIXME: we might need to use a *float64 for Start/End so we can check for unset values.
 	if caption.Start == nil {
 		return fmt.Errorf("invalid cue start timestamp")
@@ -109,46 +165,4 @@ func (r *reader) validateTimings(caption *caps.Caption, lastStartTime float64) e
 		return fmt.Errorf("start timestamp is not greater to start timestamp of previous cue")
 	}
 	return nil
-}
-
-func (r *reader) removeStyles(line string) string {
-	partialResult := voiceSpanPattern.ReplaceAllString(line, "\\2: ")
-	return otherSpanPattern.ReplaceAllString(partialResult, "")
-}
-
-func (r *reader) parseTimingLine(line string, lastStartTime float64) (*caps.Caption, error) {
-	matches := timingPattern.FindAllString(line, -1)
-	if len(matches) == 0 {
-		return nil, fmt.Errorf("invalid timing format")
-	}
-	start, err := r.parseTimestamp(string(matches[1]))
-	if err != nil {
-		return nil, err
-	}
-	end, err := r.parseTimestamp(string(matches[2]))
-	if err != nil {
-		return nil, err
-	}
-	caption := &caps.Caption{Start: start, End: end}
-	if !r.ignoreTimingErrors {
-		r.validateTimings(caption, lastStartTime)
-	}
-	return caption, nil
-}
-
-func (r *reader) parseTimestamp(input string) (*float64, error) {
-	matches := timestampPattern.FindAllString(input, -1)
-	if len(matches) < 4 {
-		return nil, nil
-	}
-	if matches[2] != "" {
-		tmstp, err := microseconds(matches[0], matches[1], strings.ReplaceAll(matches[2], ":", ""), matches[3])
-		return &tmstp, err
-	}
-	tmstp, err := microseconds("0", matches[0], matches[1], matches[3])
-	return &tmstp, err
-}
-
-func (r *reader) Detect(content []byte) bool {
-	return strings.Contains(string(content), "WEBVTT")
 }

--- a/webvtt/reader.go
+++ b/webvtt/reader.go
@@ -1,6 +1,7 @@
 package webvtt
 
 import (
+	"bytes"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -84,7 +85,7 @@ func (r *reader) parse(lines []string) ([]*caps.Caption, error) {
 }
 
 func (r *reader) Detect(content []byte) bool {
-	return strings.Contains(string(content), "WEBVTT")
+	return bytes.HasPrefix(content, []byte("WEBVTT"))
 }
 
 // Reader helpers

--- a/webvtt/reader_test.go
+++ b/webvtt/reader_test.go
@@ -3,6 +3,7 @@ package webvtt
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/vimeo/caps"
 )
 
@@ -33,21 +34,27 @@ const sampleWebVTT2 = `WEBVTT
 1
 00:00:00.000 --> 00:00:43.000
 - HELLO WORLD!
+
 2
 00:00:59.000 --> 00:01:30.000
 - LOOKING GOOOOD.
+
 3
 00:01:40.000 --> 00:02:00.000
 - HA HA HA!
+
 4
 00:02:05.105 --> 00:03:07.007
 - HI. WELCOME TO SESAME STREET.
+
 5
 00:04:07.007 --> 00:05:38.441
 ON TONIGHT'S SHOW...
+
 6
 00:05:58.441 --> 00:06:40.543
 - I'M NOT GOING TO WATCH THIS.
+
 7
 00:07:10.543 --> 00:07:51.711
 HEY. WATCH THIS.
@@ -68,4 +75,134 @@ func TestCaptionLength(t *testing.T) {
 	if len(captions.GetCaptions(caps.DefaultLang)) != 7 {
 		t.Error("there should be 7 captions for default lang")
 	}
+}
+
+func TestMicroseconds(t *testing.T) {
+	var tests = []struct {
+		name     string
+		input    []string
+		expected float64
+		err      string
+	}{
+		{"parse hh:mm:ss.ttt - milliseconds", []string{"00", "00", "00", "999"}, 999000, ""},
+		{"parse hh:mm:ss.ttt - seconds", []string{"00", "00", "59", "000"}, 59000000, ""},
+		{"parse hh:mm:ss.ttt - mins", []string{"00", "59", "00", "000"}, 3540000000, ""},
+		{"parse hh:mm:ss.ttt - hour", []string{"23", "00", "00", "000"}, 82800000000, ""},
+		{"parse hh:mm:ss.ttt", []string{"23", "59", "59", "999"}, 86399999000, ""},
+		{"parse invalid milliseconds", []string{"23", "59", "59", "9z9"}, 0, "strconv.ParseFloat: parsing \"9z9\": invalid syntax"},
+		{"parse invalid seconds", []string{"23", "59", "5z", "999"}, 0, "strconv.ParseFloat: parsing \"5z\": invalid syntax"},
+		{"parse invalid minutes", []string{"23", "5z", "59", "999"}, 0, "strconv.ParseFloat: parsing \"5z\": invalid syntax"},
+		{"parse invalid hours", []string{"2z", "59", "59", "999"}, 0, "strconv.ParseFloat: parsing \"2z\": invalid syntax"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := microseconds(tt.input[0], tt.input[1], tt.input[2], tt.input[3])
+			if tt.err == "" {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, actual)
+			} else {
+				assert.EqualError(t, err, tt.err)
+			}
+
+		})
+	}
+}
+
+func TestParseTimingLine(t *testing.T) {
+	var tests = []struct {
+		name               string
+		line               string
+		lastTime           float64
+		ignoreTimingErrors bool
+		expected           caps.Caption
+		err                string
+	}{
+		{"parse valid cue - without validation", "00:00:50.000 --> 00:00:51.999", 49000000, true, caps.Caption{Start: floatPtr(50000000), End: floatPtr(51999000)}, ""},
+		{"parse valid cue - with validation", "00:00:50.000 --> 00:00:51.999", 49000000, false, caps.Caption{Start: floatPtr(50000000), End: floatPtr(51999000)}, ""},
+		{"parse invalid cue - without validation", "00:00:50.000 --> 00:00:51.999", 59000000, true, caps.Caption{Start: floatPtr(50000000), End: floatPtr(51999000)}, ""},
+		{"parse invalid cue - with validation", "00:00:50.000 --> 00:00:51.999", 59000000, false, caps.Caption{}, "start timestamp is not greater to start timestamp of previous cue"},
+		{"parse invalid cue - with validation", "00:00:52.000 --> 00:00:51.999", 49000000, false, caps.Caption{}, "end timestamp is not greater than start timestamp"},
+		{"parse invalid timing line - missing end cue", "00:00:50.000 -->", 49000000, false, caps.Caption{}, "invalid timing format"},
+		{"parse invalid timing line - missing start cue", "--> 00:00:51.999", 49000000, false, caps.Caption{}, "invalid timing format"},
+		{"parse invalid timing line - invalid end cue", "00:00:50.000 --> 00:00:5x.999", 49000000, false, caps.Caption{}, "invalid cue end timestamp"},
+		{"parse invalid timing line - invalid start cue", "00:00:5x.000 --> 00:00:51.999", 49000000, false, caps.Caption{}, "invalid cue start timestamp"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := parseTimingLine(tt.line, tt.lastTime, tt.ignoreTimingErrors)
+			if tt.err == "" {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, *actual)
+			} else {
+				assert.EqualError(t, err, tt.err)
+			}
+
+		})
+	}
+}
+
+func TestParseTimestamp(t *testing.T) {
+	var tests = []struct {
+		name     string
+		input    string
+		expected float64
+		err      string
+	}{
+		{"parse hh:mm:ss.ttt - milliseconds", "00:00:00.999", 999000, ""},
+		{"parse hh:mm:ss.ttt - seconds", "00:00:59.000", 59000000, ""},
+		{"parse hh:mm:ss.ttt - mins", "00:59:00.000", 3540000000, ""},
+		{"parse hh:mm:ss.ttt - hour", "23:00:00.000", 82800000000, ""},
+		{"parse hh:mm:ss.ttt", "23:59:59.999", 86399999000, ""},
+		{"parse mm:ss.ttt - milliseconds", "00:00.999", 999000, ""},
+		{"parse mm:ss.ttt - seconds", "00:59.000", 59000000, ""},
+		{"parse mm:ss.ttt - mins", "59:00.000", 3540000000, ""},
+		{"parse mm:ss.ttt", "59:59.999", 3599999000, ""},
+		{"parse invalid timestamp", "00:23:59:59.999", 0, "nil"},
+		{"parse invalid timestamp", "59.999", 0, "nil"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := parseTimestamp(tt.input)
+			if tt.err == "" {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, *actual)
+			} else {
+				assert.Equal(t, nil, err)
+			}
+
+		})
+	}
+}
+
+func TestRemoveStyles(t *testing.T) {
+	var tests = []struct {
+		name     string
+		input    string
+		expected string
+		err      string
+	}{
+		{"remove styles - voice span", "<v Bob>text</v>", "\\2: text", ""},
+		{"remove styles - italic span", "<i>Yellow!</i>", "Yellow!", ""},
+		{"remove styles - bold span", "<b>Yellow!</b>", "Yellow!", ""},
+		{"remove styles - underline span", "<u>Yellow!</u>", "Yellow!", ""},
+		{"remove styles - language span", "<lang en>Yellow!</lang>", "Yellow!", ""},
+		{"remove styles - ruby span", "<ruby.loud>Yellow! <rt.loud>Yellow!</rt></ruby>", "Yellow! Yellow!", ""},
+		{"remove styles - color span", "<c.yellow.bg_blue.magenta.bg_black>Yellow!</c>", "Yellow!", ""},
+		{"remove styles - nested style spans", "Sur les <i.foreignphrase><lang en>playground</lang></i>, ici à Montpellier", "Sur les playground, ici à Montpellier", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := removeStyles(tt.input)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+// test helpers
+func floatPtr(x float64) *float64 {
+	return &x
 }


### PR DESCRIPTION
- Fix `timestampPattern` regex so that we can match on hh:mm:ss and mm:ss timestamps
- Replaces `FindAllString` with `FindStringSubmatch` in `parseTimingLine`, `parseTimestamp` to capture the matches on the regex pattern
- Adds test for the VTT Reader helper functions
- Replace magic numbers with constants