### PR TITLE
Add SAMI parser

### DIFF
--- a/sami/parser.go
+++ b/sami/parser.go
@@ -129,8 +129,11 @@ func (p *parser) parse() error {
 // nodeStack is a stack of nodes.
 type nodeStack []*html.Node
 
-// pop pops the stack. It will panic if s is empty.
+// pop pops the stack.
 func (s *nodeStack) pop() *html.Node {
+	if len(*s) == 0 {
+		return nil
+	}
 	i := len(*s)
 	n := (*s)[i-1]
 	*s = (*s)[:i-1]

--- a/sami/parser.go
+++ b/sami/parser.go
@@ -1,0 +1,146 @@
+package sami
+
+import (
+	"io"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// Parse returns the root of parsed SAMI tree that was read from the io.Reader.
+//
+// It doesn't implement the SAMI spec and its basically a super simple tag parser,
+// watered down from golang.org/x/net/html, using its tokenizer.
+// The main reason we had to create this is just so we can have an html-like parser that
+// doesn't enforce HTML5 spec restrictions and semantics(e.g. requiring
+// the document to have an html root with head/body, html5 semantics, etc).
+// Since most golang pkgs for parsing/querying/editing html do parsing using golang.org/x/net/html,
+// they all end up messing with the resulting SAMI tree, which can lead to
+// weird/unexpected results, so this fixes that.
+//
+// The input is assumed to be UTF-8 encoded.
+func Parse(r io.Reader) (*html.Node, error) {
+	p := &parser{
+		tokenizer: html.NewTokenizer(r),
+		root: &html.Node{
+			Type: html.DocumentNode,
+		},
+	}
+	// this is default value already, but lets force it anyways
+	p.tokenizer.AllowCDATA(false)
+	if err := p.parse(); err != nil {
+		return nil, err
+	}
+	return p.root, nil
+}
+
+type parser struct {
+	// tokenizer provides the tokens for the parser.
+	tokenizer *html.Tokenizer
+	// tok is the most recently read token.
+	tok html.Token
+	// root is the root element of sami tree.
+	root *html.Node
+	// The stack of open elements
+	oe nodeStack
+}
+
+// top method returns the current open tag on the stack or the top most one(the root parent)
+func (p *parser) top() *html.Node {
+	if n := p.oe.top(); n != nil {
+		return n
+	}
+	return p.root
+}
+
+// addChild adds a child node n to the top element, and pushes n onto the stack
+// of open elements if it is an element node.
+func (p *parser) addChild(n *html.Node) {
+	p.top().AppendChild(n)
+	if n.Type == html.ElementNode {
+		p.oe = append(p.oe, n)
+	}
+}
+
+// addText adds text to the preceding node if it is a text node, or else it
+// calls addChild with a new text node.
+func (p *parser) addText(text string) {
+	if text == "" {
+		return
+	}
+	t := p.top()
+	if n := t.LastChild; n != nil && n.Type == html.TextNode {
+		n.Data += text
+		return
+	}
+	p.addChild(&html.Node{
+		Type: html.TextNode,
+		Data: text,
+	})
+}
+
+// addElement adds a child element based on the current token.
+func (p *parser) addElement() {
+	p.addChild(&html.Node{
+		Type:     html.ElementNode,
+		DataAtom: p.tok.DataAtom,
+		Data:     p.tok.Data,
+		Attr:     p.tok.Attr,
+	})
+}
+
+// parseCurrentToken runs the current token through the parsing routines
+// until it is consumed.
+func (p *parser) parseCurrentToken() {
+	switch p.tok.Type {
+	case html.TextToken:
+		d := p.tok.Data
+		d = strings.ReplaceAll(d, "\x00", "")
+		if d == "" {
+			return
+		}
+		p.addText(d)
+	case html.SelfClosingTagToken:
+		p.addElement()
+		p.oe.pop()
+	case html.StartTagToken:
+		p.addElement()
+	case html.EndTagToken:
+		p.oe.pop()
+	}
+}
+
+func (p *parser) parse() error {
+	var err error
+	for err != io.EOF {
+		p.tokenizer.Next()
+		p.tok = p.tokenizer.Token()
+		if p.tok.Type == html.ErrorToken {
+			err = p.tokenizer.Err()
+			if err != nil && err != io.EOF {
+				return err
+			}
+		}
+		p.parseCurrentToken()
+	}
+	return nil
+}
+
+// nodeStack is a stack of nodes.
+type nodeStack []*html.Node
+
+// pop pops the stack. It will panic if s is empty.
+func (s *nodeStack) pop() *html.Node {
+	i := len(*s)
+	n := (*s)[i-1]
+	*s = (*s)[:i-1]
+	return n
+}
+
+// top returns the most recently pushed node, or nil if s is empty.
+func (s *nodeStack) top() *html.Node {
+	if i := len(*s); i > 0 {
+		return (*s)[i-1]
+	}
+	return nil
+}

--- a/sami/parser_test.go
+++ b/sami/parser_test.go
@@ -1,0 +1,393 @@
+package sami
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/andreyvit/diff"
+	"golang.org/x/net/html"
+)
+
+func render(n *html.Node) string {
+	var buf bytes.Buffer
+	w := io.Writer(&buf)
+	html.Render(w, n)
+	return buf.String()
+}
+
+func TestParser(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       io.Reader
+		expected    string
+		expectedErr bool
+	}{
+		{
+			name:  "sami with multiple styles",
+			input: strings.NewReader(sample1),
+			expected: `<sami>
+        <head>
+          <title>test123</title>
+          <style type="text/css">
+            <!--
+            P { margin-right:  1pt; }
+            -->
+          </style>
+          <style type="text/css">
+            <!--
+            P { margin-left:  1pt; color: #ffeedd; }
+            .ENCC {Name: English; lang: en-US; SAMI_Type: CC;}
+            -->
+          </style>
+        </head>
+        <body>
+          <sync start="9209">
+            <p class="ENCC">
+              ( clock ticking )
+            </p>
+          </sync>
+          <sync start="12312"><p class="ENCC"> </p></sync>
+          <sync start="14848">
+            <p class="ENCC">
+              MAN:<br/>
+              When we think<br/>
+              of &#34;E equals m c-squared&#34;,
+            </p>
+          </sync>
+        </body>
+      </sami>`,
+			expectedErr: false,
+		},
+		{
+			name:  "sami with encoded chars",
+			input: strings.NewReader(sample2),
+			expected: `<sami>
+        <head>
+          <title>test123</title>
+          <style type="text/css">
+          <!--
+          P { margin-left:  1pt; color: #ffeedd; }
+          .ENCC {Name: English; lang: en-US; SAMI_Type: CC;}
+          -->
+          </style>
+        </head>
+        <body>
+          <sync start="12312"><p class="ENCC"> </p></sync>
+          <sync start="17000">
+          <p class="ENCC">
+          <span style="text-align:right;">we have this vision of Einstein</span>
+          </p>
+          </sync>
+          <sync start="32200">
+          <p class="ENCC">
+          &lt;LAUGHING &amp; WHOOPS!&gt;
+          </p>
+          </sync>
+        </body>
+      </sami>`,
+			expectedErr: false,
+		},
+		{
+			name:  "sami with tts span style",
+			input: strings.NewReader(ttsSample),
+			expected: `
+        <sami>
+          <head>
+          </head>
+          <body>
+            <sync start="6534661"><p class="ENCC">
+            <span tts:fontstyle="italic">NOVA</span> is <span foo="bar">a</span> production<br/>
+            of WGBH Boston.
+            </p></sync>
+          </body>
+        </sami>`,
+			expectedErr: false,
+		},
+		{
+			name:  "sami with tts span style",
+			input: strings.NewReader(ttsSample),
+			expected: `
+              <sami>
+                <head>
+                </head>
+                <body>
+                  <sync start="6534661"><p class="ENCC">
+                  <span tts:fontstyle="italic">NOVA</span> is <span foo="bar">a</span> production<br/>
+                  of WGBH Boston.
+                  </p></sync>
+                </body>
+              </sami>`,
+			expectedErr: false,
+		},
+		{
+			name:  "follows whatever the tokenizer parses when handling invalid tag syntax",
+			input: strings.NewReader(syntaxErrorSample),
+			expected: `
+        <sami>
+        <head>
+        <title>ir2014_111</title>
+        <style type="text/css">
+        <!--
+        P { margin-left:  1pt;
+        margin-right: 1pt;
+        margin-bottom: 2pt;
+        margin-top: 2pt;
+        text-align: center;
+        font-size: 10pt;
+        font-family: Arial;
+        font-weight: normal;
+        font-style: normal;
+        color: #ffffff; }
+
+        #Small {Name:SmallTxt; font-family:Arial;font-weight:normal;font-size:10pt;color:#ffffff;}
+        #Big {Name:BigTxt; font-family:Arial;font-weight:bold;font-size:12pt;color:#ffffff;}
+
+        .ENCC {Name:English; lang: en-US; SAMI_Type: CC;}
+
+        -->
+
+        </style>
+        </head>
+        <body>
+        <sync start="0"><p class="ENCC">
+        <sync start="5905"><p class="ENCC">&gt;&gt;&gt; PRESENTATION OF &#34;IDAHO<br`,
+			expectedErr: false,
+		},
+		{
+			name:  "can handle tag nesting properly",
+			input: strings.NewReader(nestedTags),
+			expected: `
+        <sami>
+          <head>
+          </head>
+          <body>
+            <p>
+              something
+              <span>
+                <span>
+                  <span>
+                    <span>
+                      else
+                    </span>
+                  </span>
+                </span>
+              </span>
+            </p>
+            <p>another p</p>
+          </body>
+        </sami>`,
+			expectedErr: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			root, err := Parse(test.input)
+			if err != nil && !test.expectedErr {
+				tt.Errorf("got unexpected error: %s", err)
+			}
+			s := render(root)
+			if e, g := diff.TrimLinesInString(test.expected), diff.TrimLinesInString(s); e != g {
+				tt.Errorf("unexpected result:\n%v", diff.LineDiff(e, g))
+			}
+		})
+	}
+}
+
+const (
+	ttsSample = `
+  <SAMI>
+  <HEAD>
+  </HEAD>
+  <BODY>
+  <SYNC start="6534661"><P class="ENCC">
+      <span tts:fontStyle="italic">NOVA</span> is <span foo="bar">a</span> production<br/>
+         of WGBH Boston.
+</P></SYNC>
+</BODY>
+  `
+	pycaptionSample = `<SAMI>
+  <HEAD>
+    <TITLE>NOVA3213</TITLE>
+    <STYLE TYPE="text/css">
+    <!--
+    P { margin-left:  1pt;
+        margin-right: 1pt;
+        margin-bottom: 2pt;
+        margin-top: 2pt;
+        text-align: center;
+        font-size: 10pt;
+        font-family: Arial;
+        font-weight: normal;
+        font-style: normal;
+        color: #ffeedd; }
+
+    .ENCC {Name: English; lang: en-US; SAMI_Type: CC;}
+
+    -->
+    </STYLE>
+  </HEAD>
+  <BODY>
+    <SYNC start="9209">
+      <P class="ENCC">
+        ( clock ticking )
+      </P>
+    </SYNC>
+    <SYNC start="12312"><P class="ENCC">&nbsp;</P></SYNC>
+    <SYNC start="14848">
+      <P class="ENCC">
+        MAN:<br/>
+        When we think<br/>
+        of "E equals m c-squared",
+      </P>
+    </SYNC>
+    <SYNC start="17000">
+      <P class="ENCC">
+        <SPAN Style="text-align:right;">we have this vision of Einstein</SPAN>
+      </P>
+    </SYNC>
+    <SYNC start="18752">
+      <P class="ENCC">
+        as an old, wrinkly man<br/>
+        with white hair.
+      </P>
+    </SYNC>
+    <SYNC start="20887">
+      <P class="ENCC">
+        MAN 2:<br/>
+        E equals m c-squared is<br/>
+        not about an old Einstein.
+      </P>
+    </SYNC>
+    <SYNC start="26760">
+      <P class="ENCC">
+        MAN 2:<br/>
+        It's all about an eternal Einstein.
+      </P>
+    </SYNC>
+    <SYNC start="32200">
+      <P class="ENCC">
+        &lt;LAUGHING &amp; WHOOPS!&gt;
+      </P>
+    </SYNC>
+    <SYNC start="34400">
+      <P class="ENCC">
+        <br/>some more text
+      </P>
+    </SYNC>
+  </BODY>
+</SAMI>`
+	sample1 = `
+<SAMI>
+  <HEAD>
+    <TITLE>test123</TITLE>
+    <STYLE type="text/css">
+      <!--
+      P { margin-right:  1pt; }
+      -->
+    </STYLE>
+    <STYLE TYPE="text/css">
+    <!--
+    P { margin-left:  1pt; color: #ffeedd; }
+    .ENCC {Name: English; lang: en-US; SAMI_Type: CC;}
+    -->
+    </STYLE>
+  </HEAD>
+  <BODY>
+    <SYNC start="9209">
+      <P class="ENCC">
+        ( clock ticking )
+      </P>
+    </SYNC>
+    <SYNC start="12312"><P class="ENCC">&nbsp;</P></SYNC>
+    <SYNC start="14848">
+      <P class="ENCC">
+        MAN:<br/>
+        When we think<br/>
+        of "E equals m c-squared",
+      </P>
+    </SYNC>
+  </BODY>
+</SAMI>`
+
+	sample2 = `<SAMI>
+  <HEAD>
+    <TITLE>test123</TITLE>
+    <STYLE TYPE="text/css">
+    <!--
+    P { margin-left:  1pt; color: #ffeedd; }
+    .ENCC {Name: English; lang: en-US; SAMI_Type: CC;}
+    -->
+    </STYLE>
+  </HEAD>
+  <BODY>
+    <SYNC start="12312"><P class="ENCC">&nbsp;</P></SYNC>
+    <SYNC start="17000">
+      <P class="ENCC">
+        <SPAN Style="text-align:right;">we have this vision of Einstein</SPAN>
+      </P>
+    </SYNC>
+    <SYNC start="32200">
+      <P class="ENCC">
+        &lt;LAUGHING &amp; WHOOPS!&gt;
+      </P>
+    </SYNC>
+  </BODY>
+</SAMI>`
+
+	syntaxErrorSample = `
+<SAMI>
+<Head>
+<title>ir2014_111</title>
+  <STYLE TYPE="text/css">
+    <!--
+    P { margin-left:  1pt;
+      margin-right: 1pt;
+      margin-bottom: 2pt;
+      margin-top: 2pt;
+      text-align: center;
+      font-size: 10pt;
+      font-family: Arial;
+      font-weight: normal;
+      font-style: normal;
+      color: #ffffff; }
+
+    #Small {Name:SmallTxt; font-family:Arial;font-weight:normal;font-size:10pt;color:#ffffff;}
+    #Big {Name:BigTxt; font-family:Arial;font-weight:bold;font-size:12pt;color:#ffffff;}
+
+    .ENCC {Name:English; lang: en-US; SAMI_Type: CC;}
+
+    -->
+
+  </Style>
+</Head>
+<BODY>
+<Sync Start=0><P Class=ENCC>
+<Sync Start=5905><P Class=ENCC>>>> PRESENTATION OF "IDAHO<br>REPORTS" ON IDAHO PUBLIC
+<Sync Start=7073><P Class=ENCC>TELEVISION IS MADE POSSIBLE<br>THROUGH THE GENEROUS SUPPORT OF
+
+</Body>
+</SAMI>
+`
+	nestedTags = `
+  <sami>
+    <head>
+    </head>
+  <body>
+    <p>
+      something
+      <span>
+        <span>
+          <span>
+            <span>
+              else
+            </span>
+          </span>
+        </span>
+      </span>
+    </p>
+    <p>another p</p>
+  </body>
+  `
+)

--- a/sami/parser_test.go
+++ b/sami/parser_test.go
@@ -180,6 +180,12 @@ func TestParser(t *testing.T) {
         </sami>`,
 			expectedErr: false,
 		},
+		{
+			name:        "ignores tag without a pair",
+			input:       strings.NewReader(`<sami></body></sami>`),
+			expected:    `<sami></sami>`,
+			expectedErr: false,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {


### PR DESCRIPTION
This adds a basic tag parser using `golang.org/x/net/html`'s tokenizer. The main goal here is parsing all the tags naively without having to infer/enforce any HTML5 spec restrictions/rules(which is what `html.Parse` will do if we feed it a SAMI file). Since we're still using `html.Node`s to represent the SAMI tree, we'll still be able to use something like `github.com/PuerkitoBio/goquery` to query and edit the tree in the SAMI reader/writer.

TLDR: Most of the code here is based on `golang.org/x/net/html` html parser, just removing all HTML5 semantic inference/enforcement. Example of what happens if we parse SAMI with the original html parser: https://go.dev/play/p/GTnOVGkcYsx
